### PR TITLE
Can now disable exwm auto keybinding

### DIFF
--- a/exwm-edit.el
+++ b/exwm-edit.el
@@ -58,6 +58,11 @@
   :type 'hook
   :group 'exwm-edit)
 
+(defcustom exwm-edit-bind-default-keys t
+  "If non-nil bind default keymaps on load."
+  :type 'boolean
+  :group 'exwm-edit)
+
 (defun exwm-edit--finish ()
   "Called when done editing buffer created by `exwm-edit--compose'."
   (interactive)
@@ -147,8 +152,9 @@
                (substitute-command-keys
                 "Edit, then exit with `\\[exwm-edit--finish]' or cancel with \ `\\[exwm-edit--cancel]'")))))))))
 
-(exwm-input-set-key (kbd "C-c '") #'exwm-edit--compose)
-(exwm-input-set-key (kbd "C-c C-'") #'exwm-edit--compose)
+(when exwm-edit-bind-keys
+  (exwm-input-set-key (kbd "C-c '") #'exwm-edit--compose)
+  (exwm-input-set-key (kbd "C-c C-'") #'exwm-edit--compose))
 
 (provide 'exwm-edit)
 

--- a/exwm-edit.el
+++ b/exwm-edit.el
@@ -152,7 +152,7 @@
                (substitute-command-keys
                 "Edit, then exit with `\\[exwm-edit--finish]' or cancel with \ `\\[exwm-edit--cancel]'")))))))))
 
-(when exwm-edit-bind-keys
+(when exwm-edit-bind-default-keys
   (exwm-input-set-key (kbd "C-c '") #'exwm-edit--compose)
   (exwm-input-set-key (kbd "C-c C-'") #'exwm-edit--compose))
 


### PR DESCRIPTION
It's a pain to remove the keybinds this mode adds on load. This allows you to customize it but you have to do it before loading it since when it's loaded it's too late because they are still bound on load. You would have to add a mode that you can enable after loading this package to fix that though