### PR TITLE
Added minibuffer support, refractored

### DIFF
--- a/exwm-edit.el
+++ b/exwm-edit.el
@@ -48,6 +48,11 @@
   :type 'hook
   :group 'exwm-edit)
 
+(defcustom exwm-edit-compose-minibuffer-hook nil
+  "Customizable hook, runs after `exwm-edit--compose-minibuffer' buffer created."
+  :type 'hook
+  :group 'exwm-edit)
+
 (defcustom exwm-edit-before-finish-hook nil
   "Customizable hook, runs before `exwm-edit--finish'."
   :type 'hook
@@ -173,13 +178,10 @@ parameter of `completing-read'"
         (global-exwm-edit-mode 1))
       (progn
         (when unmarked? (exwm-input--fake-key ?\C-a))
-        (let ((buffer (get-buffer-create title)))
-          (with-current-buffer buffer
-            (run-hooks 'exwm-edit-compose-hook)
-            (exwm-edit-mode 1)
-            (let ((sel (gui-get-selection)))
-	      (exwm-edit--send-to-exwm-buffer
-	       (completing-read "exwm-edit: " completing-read-entries nil nil sel)))))))))
+        (run-hooks 'exwm-edit-compose-minibuffer-hook)
+        (let ((sel (gui-get-selection)))
+	  (exwm-edit--send-to-exwm-buffer
+	   (completing-read "exwm-edit: " completing-read-entries nil nil sel)))))))
 
 (exwm-input-set-key (kbd "C-c '") #'exwm-edit--compose)
 (exwm-input-set-key (kbd "C-c C-'") #'exwm-edit--compose)

--- a/exwm-edit.el
+++ b/exwm-edit.el
@@ -152,8 +152,10 @@
                (substitute-command-keys
                 "Edit, then exit with `\\[exwm-edit--finish]' or cancel with \ `\\[exwm-edit--cancel]'")))))))))
 
-(defun exwm-edit--compose-minibuffer ()
-  "Edit text in an EXWM app."
+(defun exwm-edit--compose-minibuffer (&optional completing-read-entries)
+  "Edit text in an EXWM app.
+If COMPLETING-READ-ENTRIES is non-nil, feed that list into the collection
+parameter of `completing-read'"
   (interactive)
   ;; flushing clipboard is required, otherwise `gui-get-selection` simply picks up what's in the clipboard (when nothing is actually selected in GUI)
   (gui-set-selection nil nil)
@@ -177,7 +179,7 @@
             (exwm-edit-mode 1)
             (let ((sel (gui-get-selection)))
 	      (exwm-edit--send-to-exwm-buffer
-	       (completing-read "exwm-edit: " nil nil nil sel)))))))))
+	       (completing-read "exwm-edit: " completing-read-entries nil nil sel)))))))))
 
 (exwm-input-set-key (kbd "C-c '") #'exwm-edit--compose)
 (exwm-input-set-key (kbd "C-c C-'") #'exwm-edit--compose)

--- a/exwm-edit.el
+++ b/exwm-edit.el
@@ -43,6 +43,12 @@
 (defvar exwm-edit--last-exwm-buffer nil
   "Last buffer that invoked `exwm-edit'.")
 
+(defcustom exwm-edit-split-below nil
+  "If non-nil `exwm-edit--compose' splits the window below.
+Otherwise split the window to the right."
+  :type 'boolean
+  :group 'exwm-edit)
+
 (defcustom exwm-edit-compose-hook nil
   "Customizable hook, runs after `exwm-edit--compose' buffer created."
   :type 'hook
@@ -79,7 +85,8 @@
   (let ((buffer (switch-to-buffer exwm-edit--last-exwm-buffer)))
     (with-current-buffer buffer
       (exwm-input--set-focus (exwm--buffer->id (window-buffer (selected-window))))
-      (run-at-time "0.05 sec" nil (lambda () (exwm-input--fake-key ?\C-v)))
+      ;;(run-at-time "0.05 sec" nil (lambda () (exwm-input--fake-key ?\C-v)))
+      (exwm-input--fake-key ?\C-v)
       (setq exwm-edit--last-exwm-buffer nil))))
 
 (defun exwm-edit--cancel ()
@@ -148,7 +155,11 @@
             (with-current-buffer buffer
               (run-hooks 'exwm-edit-compose-hook)
               (exwm-edit-mode 1)
-              (switch-to-buffer-other-window buffer)
+	      (select-window
+	       (if exwm-edit-split-below
+		   (split-window-below)
+		 (split-window-right)))
+	      (switch-to-buffer (get-buffer-create title))
               (let ((sel (gui-get-selection)))
 		(when sel
                   (insert sel)))


### PR DESCRIPTION
This commit adds the ability to use the minibuffer instead of a dedicated window to edit text. This is useful for editing stuff like url bars in browsers when a window is overkill. It also fixes #7 which was caused by `gui-get-selection` returning nil. #9 doesn't have this fix so a simple merge might be needed