### PR TITLE
Made copying and pasting from exwm buffers to the exwm-edit buffer a lot more reliable

### DIFF
--- a/exwm-edit.el
+++ b/exwm-edit.el
@@ -57,7 +57,7 @@ If this is too low an old yank may be used instead.")
   "The delay to use when pasting text back into the exwm buffer.
 If this is too low the text might not be pasted into the exwm buffer")
 
-(defvar exwm-edit-clean-kill-ring-delay 0.05
+(defvar exwm-edit-clean-kill-ring-delay 0.10
   "The delay to clean the `kill-ring' after pasting the text back 
 to the exwm-buffer.")
 
@@ -128,8 +128,8 @@ Depending on `exwm-edit-split' and amount of visible windows on the screen."
       ;; If everything is deleted in the exwm-edit buffer, then simply delete the selected text in the exwm buffer
       (run-with-timer exwm-edit-paste-delay nil (lambda () (exwm-input--fake-key 'delete)))
 
-    (run-with-timer exwm-edit-paste-delay nil (lambda () (exwm-input--fake-key ?\C-v)
-
+    (run-with-timer exwm-edit-paste-delay nil (lambda ()
+						(exwm-input--fake-key ?\C-v)
 						;; Clean up the kill ring
 						;; It needs to be run on a timer because of some reason
 						(run-with-timer exwm-edit-clean-kill-ring-delay nil (lambda ()
@@ -186,9 +186,8 @@ Depending on `exwm-edit-split' and amount of visible windows on the screen."
 		  (lambda ()
 		    (let ((clip (substring-no-properties (gui-get-selection 'CLIPBOARD))))
 		      (unless (and exwm-edit-last-kill (string= exwm-edit-last-kill clip))
-			(yank)
-			(run-hooks 'post-command-hook)
-			;; Clean up the last kill so that the kill ring doesn't become cluttered with exwm-edit text
+			(insert clip)
+			;; Since we ran C-c before this, clean up the last kill so that the kill ring doesn't become cluttered with exwm-edit text
 			(pop kill-ring))))))
 
 (defun exwm-edit--display-buffer (buffer)

--- a/exwm-edit.el
+++ b/exwm-edit.el
@@ -148,7 +148,8 @@ Depending on `exwm-edit-split' and amount of visible windows on the screen."
     (exwm-input--set-focus (exwm--buffer->id (window-buffer (selected-window))))
     (exwm-input--fake-key 'right)
     (unless exwm-edit-split (kill-buffer current-buffer)))
-  (setq exwm-edit--last-exwm-buffer nil))
+  (setq exwm-edit--last-exwm-buffer nil)
+  (kill-new (car kill-ring)))
 
 (defvar exwm-edit-mode-map
   (let ((map (make-sparse-keymap)))
@@ -188,9 +189,7 @@ Depending on `exwm-edit-split' and amount of visible windows on the screen."
 			   (clip (when clip-raw (substring-no-properties clip-raw))))
 		      (when clip
 			(unless (and exwm-edit-last-kill (string= exwm-edit-last-kill clip))
-			  (insert clip)
-			  ;; Since we ran C-c before this, clean up the last kill so that the kill ring doesn't become cluttered with exwm-edit text
-			  (pop kill-ring)))))))
+			  (insert clip)))))))
 
 (defun exwm-edit--display-buffer (buffer)
   "Display BUFFER according to user settings."

--- a/exwm-edit.el
+++ b/exwm-edit.el
@@ -184,11 +184,13 @@ Depending on `exwm-edit-split' and amount of visible windows on the screen."
   "Yank text to Emacs buffer with check for empty strings."
   (run-with-timer exwm-edit-yank-delay nil
 		  (lambda ()
-		    (let ((clip (substring-no-properties (gui-get-selection 'CLIPBOARD))))
-		      (unless (and exwm-edit-last-kill (string= exwm-edit-last-kill clip))
-			(insert clip)
-			;; Since we ran C-c before this, clean up the last kill so that the kill ring doesn't become cluttered with exwm-edit text
-			(pop kill-ring))))))
+		    (let* ((clip-raw (gui-get-selection 'CLIPBOARD))
+			   (clip (when clip-raw (substring-no-properties clip-raw))))
+		      (when clip
+			(unless (and exwm-edit-last-kill (string= exwm-edit-last-kill clip))
+			  (insert clip)
+			  ;; Since we ran C-c before this, clean up the last kill so that the kill ring doesn't become cluttered with exwm-edit text
+			  (pop kill-ring)))))))
 
 (defun exwm-edit--display-buffer (buffer)
   "Display BUFFER according to user settings."
@@ -216,7 +218,8 @@ If NO-COPY is non-nil, don't copy over the contents of the exwm text box"
           (switch-to-buffer-other-window existing)
         (exwm-input--fake-key ?\C-a)
         (unless (or no-copy (not exwm-edit-copy-over-contents))
-	  (setq exwm-edit-last-kill (substring-no-properties (gui-get-selection 'CLIPBOARD)))
+	  (when (gui-get-selection 'CLIPBOARD)
+	    (setq exwm-edit-last-kill (substring-no-properties (gui-get-selection 'CLIPBOARD))))
 	  (exwm-input--fake-key ?\C-c))
         (with-current-buffer (get-buffer-create title)
           (run-hooks 'exwm-edit-compose-hook)
@@ -245,7 +248,8 @@ If NO-COPY is non-nil, don't copy over the contents of the exwm text box"
       (progn
         (exwm-input--fake-key ?\C-a)
 	(unless (or no-copy (not exwm-edit-copy-over-contents))
-	  (setq exwm-edit-last-kill (substring-no-properties (gui-get-selection 'CLIPBOARD)))
+	  (when (gui-get-selection 'CLIPBOARD)
+	    (setq exwm-edit-last-kill (substring-no-properties (gui-get-selection 'CLIPBOARD))))
 	  (exwm-input--fake-key ?\C-c)
 	  (exwm-edit--yank))
 	(run-hooks 'exwm-edit-compose-minibuffer-hook)


### PR DESCRIPTION
In my tests this fixes #16, might fix #7 (but I don't know, I never had that problem in the first place) and makes this package a whole lot more reliable at the cost of harder to understand code. I bumped the required emacs version to 25.1 because it's required by `(gui-get-selection 'CLIPBOARD)`. 

Given #18 I'm not sure how testing around this patch should happen. If anyone is using this package and wants to try out my patch, please report here if it works well or if there are any problems so that there is some indication that it this doesn't just work using my config and on my pc