### PR TITLE
Customize `*exwm-edit*` buffer placement with `display-buffer-action`

### DIFF
--- a/exwm-edit.el
+++ b/exwm-edit.el
@@ -162,6 +162,7 @@ Depending on `exwm-edit-split' and amount of visible windows on the screen."
 (define-minor-mode exwm-edit-mode
   "Minor mode enabled in `exwm-edit--compose' buffer"
   :init-value nil
+  :interactive nil
   :lighter " exwm-edit"
   :keymap exwm-edit-mode-map
   (if exwm-edit-mode

--- a/exwm-edit.el
+++ b/exwm-edit.el
@@ -162,7 +162,7 @@ This is then inserted into the `exwm-edit' buffer."
 
 (defun exwm-edit--buffer-title (str)
   "`exwm-edit' buffer title based on STR."
-  (concat "*exwm-edit " str " *"))
+  (format "*exwm-edit %s *" str))
 
 (defun exwm-edit--yank ()
   "Yank text to Emacs buffer with check for empty strings."

--- a/exwm-edit.el
+++ b/exwm-edit.el
@@ -96,9 +96,7 @@ This is then inserted into the `exwm-edit' buffer."
   "Called when done editing buffer created by `exwm-edit--compose'."
   (interactive)
   (run-hooks 'exwm-edit-before-finish-hook)
-  (let ((text (buffer-substring-no-properties
-	       (point-min)
-	       (point-max))))
+  (let ((text (filter-buffer-substring (point-min) (point-max))))
     (kill-buffer)
     (exwm-edit--send-to-exwm-buffer text)))
 

--- a/exwm-edit.el
+++ b/exwm-edit.el
@@ -217,16 +217,15 @@ If NO-COPY is non-nil, don't copy over the contents of the exwm text box"
          (selection-coding-system 'utf-8))             ; required for multilang-support
     (when (derived-mode-p 'exwm-mode)
       (setq exwm-edit--last-window-configuration (current-window-configuration))
-      (progn
-        (exwm-input--fake-key ?\C-a)
-	(unless (or no-copy (not exwm-edit-copy-over-contents))
-	  (when (gui-get-selection 'CLIPBOARD 'UTF8_STRING)
-	    (setq exwm-edit-last-kill (substring-no-properties (gui-get-selection 'CLIPBOARD 'UTF8_STRING))))
-	  (exwm-input--fake-key ?\C-c)
-	  (exwm-edit--yank))
-	(run-hooks 'exwm-edit-compose-minibuffer-hook)
-	(exwm-edit--send-to-exwm-buffer
-	 (completing-read "exwm-edit: " completing-read-entries))))))
+      (exwm-input--fake-key ?\C-a)
+      (unless (or no-copy (not exwm-edit-copy-over-contents))
+	(when (gui-get-selection 'CLIPBOARD 'UTF8_STRING)
+	  (setq exwm-edit-last-kill (substring-no-properties (gui-get-selection 'CLIPBOARD 'UTF8_STRING))))
+	(exwm-input--fake-key ?\C-c)
+	(exwm-edit--yank))
+      (run-hooks 'exwm-edit-compose-minibuffer-hook)
+      (exwm-edit--send-to-exwm-buffer
+       (completing-read "exwm-edit: " completing-read-entries)))))
 
 (provide 'exwm-edit)
 

--- a/readme.org
+++ b/readme.org
@@ -54,4 +54,7 @@ contents into the X program.  To discard the contents of the
 
 - Autoload ~exwm-edit--compose~ and ~exwm-edit--compose-minibuffer~
 - Just loading ~exwm-edit~ no longer binds any keys
+- Window display now uses standard ~display-buffer~ actions.
+  Customize ~exwm-edit-display-buffer-action~ instead of
+  ~exwm-edit-split~.
 - Bug fixes


### PR DESCRIPTION
Thank you for `exwm-edit`!!

Here's some extra explanation for the two main commits:

- 3943f88 replaces the globalized minor mode with a simpler, more robust way to ensure that `exwm-edit-mode-map` bindings are not shadowed when switching major mode.
- e02d2f5 replaces `exwm-edit-split` with `exwm-edit-display-buffer-action`, allowing greater flexibility in where `*exwm-edit XXX *` buffers are opened.

Since I submitted many PRs, I'm happy to rebase my work if need be.

Thanks,

Joseph